### PR TITLE
Refatora e melhora o pipeline de ETL de dados CNPJ.

### DIFF
--- a/code/.env_template
+++ b/code/.env_template
@@ -5,3 +5,4 @@ DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=postgres
 DB_NAME=Dados_RFB
+DADOS_RF_URL=http://200.152.38.155/CNPJ/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ pytz>=2021.1
 requests==2.30.0
 six>=1.16.0
 soupsieve>=2.2.1
-SQLAlchemy>=1.4.18
 typing-extensions>=3.10.0.0
 tzdata==2023.3
 urllib3==2.0.2


### PR DESCRIPTION
Este commit introduz várias melhorias no script de ETL para torná-lo mais robusto, performático e de fácil manutenção.

As principais mudanças incluem:
- **Configuração:** A URL da fonte de dados, que estava hardcoded, foi movida para o arquivo `.env` (DADOS_RF_URL) para permitir uma configuração mais fácil.
- **Performance:**
    - O desempenho da inserção no banco de dados foi significativamente melhorado ao substituir o método lento `to_sql` do pandas pelo método de carregamento em massa `psycopg2.copy_from`, que é muito mais rápido. A dependência `SQLAlchemy` foi removida, pois não é mais necessária.
    - O uso de memória foi drasticamente reduzido pelo processamento de todos os arquivos de dados grandes (`empresa`, `sócios`) em pedaços (chunks), evitando possíveis falhas em máquinas com menos RAM.
- **Tratamento de Erros:** O script não ignora mais os erros durante a descompressão de arquivos. Agora ele relata problemas com arquivos zip corrompidos e continua o processamento, tornando o pipeline mais resiliente.