### PR TITLE
Fix: Correct pandas version and wrap index DDL in text()

### DIFF
--- a/code/cnpj_processor.py
+++ b/code/cnpj_processor.py
@@ -250,10 +250,10 @@ def create_database_indexes(engine):
     logging.info("--- CRIANDO ÍNDICES NO BANCO DE DADOS ---")
     with engine.connect() as connection:
         try:
-            connection.execute("CREATE INDEX idx_empresa_cnpj ON empresa(cnpj_basico);")
-            connection.execute("CREATE INDEX idx_estabelecimento_cnpj ON estabelecimento(cnpj_basico);")
-            connection.execute("CREATE INDEX idx_socios_cnpj ON socios(cnpj_basico);")
-            connection.execute("CREATE INDEX idx_simples_cnpj ON simples(cnpj_basico);")
+            connection.execute(text("CREATE INDEX idx_empresa_cnpj ON empresa(cnpj_basico);"))
+            connection.execute(text("CREATE INDEX idx_estabelecimento_cnpj ON estabelecimento(cnpj_basico);"))
+            connection.execute(text("CREATE INDEX idx_socios_cnpj ON socios(cnpj_basico);"))
+            connection.execute(text("CREATE INDEX idx_simples_cnpj ON simples(cnpj_basico);"))
             connection.commit()
             logging.info("Índices criados com sucesso para a coluna `cnpj_basico`.")
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ greenlet>=1.1.0
 importlib-metadata>=4.5.0
 lxml>=4.6.3
 numpy>=1.20.3
-pandas>=1.2.4
+pandas>=1.4.0
 python-dateutil>=2.8.1
 python-dotenv==1.0.0
 pytz>=2021.1


### PR DESCRIPTION
This commit resolves two errors encountered during the ETL process.

1.  **`Argument raise is invalid for on_bad_lines`**: This was caused by an outdated pandas version specified in `requirements.txt`. The requirement has been updated to `pandas>=1.4.0` to ensure compatibility with the `on_bad_lines='raise'` parameter.

2.  **`sqlalchemy.exc.ObjectNotExecutableError` during index creation**: This was the same issue as a previous fix, where raw SQL was being passed to `connection.execute()`. The `CREATE INDEX` statements in the `create_database_indexes` function are now correctly wrapped in the `text()` construct.