### PR TITLE
Fix: Remove invalid sqlalchemy-pyodbc dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ wget>=3.2
 zipp>=3.4.1
 pyodbc
 sqlalchemy
-sqlalchemy-pyodbc


### PR DESCRIPTION
This commit removes the `sqlalchemy-pyodbc` package from the `requirements.txt` file.

This package does not exist on PyPI and was causing a "No matching distribution found" error during `pip install`. The `sqlalchemy` and `pyodbc` packages are sufficient for connecting to SQL Server, and the dialect is specified in the connection string, not as a separate package.